### PR TITLE
docs: add standardized CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+Welcome! We're so glad you're here and interested in contributing to Flatcar! 💖
+
+Whether you're fixing a bug, adding a feature, or improving docs — we appreciate you!
+
+For more detailed guidelines (finding issues, community meetings, PR lifecycle, commit message format, and more), check out the [main Flatcar CONTRIBUTING guide](https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md).
+
+---
+
+## Repository Specific Guidelines
+
+### Updating Source Files
+
+This repository includes source files sourced from glibc. When updating these files to a new glibc version, refer to the [`UPDATES`](./UPDATES) file.


### PR DESCRIPTION
## Summary

This PR adds a standardized `CONTRIBUTING.md` file that:

- Welcomes new contributors
- Links to the [main Flatcar CONTRIBUTING guide](https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md)
- Provides repo-specific guidelines, including a section pointing contributors to the [`UPDATES`](./UPDATES) file for guidance on rebasing against new glibc versions

This change is part of a batch update across all Flatcar repositories to ensure consistent contribution documentation.

Ref: https://github.com/flatcar/Flatcar/issues/1865